### PR TITLE
Initial works

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Note that only Linux is supported since Mininet depends on the Linux network nam
 
 ## UDP Hole Punching
 
+Please ensure that Mininet is installed before using this repo. If not, refer to [Download/Get Started With Mininet](https://mininet.org/download/) for installation instructions.
+
 ```bash
 # Start up the topology and run the Mininet CLI.
 $ sudo python3 udp-hole-punching/network.py

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # udp-hole-punching
+
+This repository provides a simulated _Restricted Cone NAT_ environment using [Mininet](https://mininet.org/) and iptables, and Python scripts for UDP Hole Punching.
+
+Note that only Linux is supported since Mininet depends on the Linux network namespaces.
+
+## Network Topology
+
+<img width="750" alt="image" src="https://github.com/ackintosh/udp-hole-punching/assets/1885716/3acf9460-b4ec-4eca-be6d-21f6d858e550">
+
+## UDP Hole Punching
+
+```bash
+# Start up the topology and run the Mininet CLI.
+$ sudo python3 udp-hole-punching/network.py
+
+# Run server script (bootstrap node) in the background.
+mininet> h0 python3 -u udp-hole-punching/server.py 0.0.0.0 9000 &
+
+# Run client script at h1.
+mininet> h1 python3 -u udp-hole-punching/client.py h0 9000 &
+
+# Run client script at h2. 
+mininet> h2 python3 -u udp-hole-punching/client.py h0 9000 &
+
+# See the logs by the server and clients.
+mininet> h1 cat /tmp/udp-hole-punching.log
+
+# See the iptable status of nat* nodes.
+mininet> nat1 iptables -L -v -n
+mininet> nat2 iptables -L -v -n
+```
+
+<img width="1468" alt="image" src="https://github.com/ackintosh/udp-hole-punching/assets/1885716/307d9944-5885-44c9-a51e-84e72449b46c">

--- a/client.py
+++ b/client.py
@@ -1,16 +1,17 @@
 import random
 import socket
-import string
+import subprocess
 import sys
 import time
 from util import *
 
 logger = logging.getLogger()
-client_id = ''.join(random.choices(string.ascii_letters, k=5))
+command = "ip -4 addr show | grep eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}'"
+private_ip = subprocess.check_output(command, shell=True).decode('utf-8').strip()
 
 
 def info(message):
-    logger.info('client(%s): %s', client_id, message)
+    logger.info('client(%s): %s', private_ip, message)
 
 
 def main(host='127.0.0.1', port=9999):
@@ -32,9 +33,9 @@ def main(host='127.0.0.1', port=9999):
         time.sleep(random.uniform(1, 5))
         msg_seq += 1
         sock.sendto(b'seq:%d' % msg_seq, peer_addr)
-        info('client: sent a message to: {}'.format(peer_addr))
+        info('sent a message to: {}'.format(peer_addr))
         data, addr = sock.recvfrom(1024)
-        info('client: received from {}: {}'.format(addr, data))
+        info('received from {}: {}'.format(addr, data))
 
 
 if __name__ == '__main__':

--- a/client.py
+++ b/client.py
@@ -1,23 +1,30 @@
-import logging
 import random
 import socket
+import string
 import sys
 import time
 from util import *
 
 logger = logging.getLogger()
+client_id = ''.join(random.choices(string.ascii_letters, k=5))
+
+
+def info(message):
+    logger.info('client(%s): %s', client_id, message)
 
 
 def main(host='127.0.0.1', port=9999):
-    sock = socket.socket(socket.AF_INET, # Internet
-                         socket.SOCK_DGRAM) # UDP
+    sock = socket.socket(
+        socket.AF_INET,  # Internet
+        socket.SOCK_DGRAM  # UDP
+    )
     sock.sendto(b'0', (host, port))
-    logger.info('client: sent a message to the server')
+    info('sent a message to the server')
 
     data, addr = sock.recvfrom(1024)
     if addr[0] != host:
         raise Exception('A message from unexpected host: %s' % addr)
-    logger.info('client: received a message from the server(%s): %s', addr[0], data)
+    info('received a message from the server(%s): %s' % (addr[0], data))
 
     peer_addr = msg_to_addr(data)
     msg_seq = 0
@@ -25,9 +32,9 @@ def main(host='127.0.0.1', port=9999):
         time.sleep(random.uniform(1, 5))
         msg_seq += 1
         sock.sendto(b'seq:%d' % msg_seq, peer_addr)
-        logger.info('client: sent a message to: {}'.format(peer_addr))
+        info('client: sent a message to: {}'.format(peer_addr))
         data, addr = sock.recvfrom(1024)
-        logger.info('client: received from {}: {}'.format(addr, data))
+        info('client: received from {}: {}'.format(addr, data))
 
 
 if __name__ == '__main__':

--- a/client.py
+++ b/client.py
@@ -1,0 +1,35 @@
+import logging
+import random
+import socket
+import sys
+import time
+from util import *
+
+logger = logging.getLogger()
+
+
+def main(host='127.0.0.1', port=9999):
+    sock = socket.socket(socket.AF_INET, # Internet
+                         socket.SOCK_DGRAM) # UDP
+    sock.sendto(b'0', (host, port))
+    logger.info('client: sent a message to the server')
+
+    data, addr = sock.recvfrom(1024)
+    if addr[0] != host:
+        raise Exception('A message from unexpected host: %s' % addr)
+    logger.info('client: received a message from the server(%s): %s', addr[0], data)
+
+    peer_addr = msg_to_addr(data)
+    msg_seq = 0
+    while True:
+        time.sleep(random.uniform(1, 5))
+        msg_seq += 1
+        sock.sendto(b'seq:%d' % msg_seq, peer_addr)
+        logger.info('client: sent a message to: {}'.format(peer_addr))
+        data, addr = sock.recvfrom(1024)
+        logger.info('client: received from {}: {}'.format(addr, data))
+
+
+if __name__ == '__main__':
+    init_logger()
+    main(*addr_from_args(sys.argv))

--- a/network.py
+++ b/network.py
@@ -83,21 +83,21 @@ class RestrictedConeNAT(Node):
         self.cmd( 'iptables -P FORWARD ACCEPT' )
 
         # # Install NAT rules
-        # iptables -t nat -A POSTROUTING -o eth1 -p udp -j SNAT --to-source <public ip goes here>
+        # iptables -t nat -A POSTROUTING -o nat1-eth0 -p udp -j SNAT --to-source 10.0.0.4/8
         self.cmd( 'iptables -t nat -A POSTROUTING',
-                  '-o', params.get('inetIntf'), '-p udp', '--to-source', params.get('ip'), '-j SNAT' )
+                  '-o', params.get('inetIntf'), '-p udp', '-j SNAT', '--to-source', params.get('ip').split('/')[0], verbose=True )
 
         # iptables -t nat -A PREROUTING -i eth1 -p udp -j DNAT --to-destination <private ip goes here>
         self.cmd( 'iptables -t nat -A PREROUTING',
-                  '-i', params.get('inetIntf'), '-p udp', '--to-destination', params.get('hostIp'), '-j DNAT' )
+                  '-i', params.get('inetIntf'), '-p udp', '-j DNAT', '--to-destination', params.get('hostIp'), verbose=True )
 
         # iptables -A INPUT -i eth1 -p udp -m state --state ESTABLISHED,RELATED -j ACCEPT
         self.cmd( 'iptables -A INPUT',
-                  '-i', params.get('inetIntf'), '-p udp', '-m state', '--state ESTABLISHED,RELATED', '-j ACCEPT' )
+                  '-i', params.get('inetIntf'), '-p udp', '-m state', '--state ESTABLISHED,RELATED', '-j ACCEPT', verbose=True )
 
         # iptables -A INPUT -i eth1 -p udp -m state --state NEW -j DROP
         self.cmd( 'iptables -A INPUT',
-                  '-i', params.get('inetIntf'), '-p udp', '-m state', '--state NEW', '-j DROP' )
+                  '-i', params.get('inetIntf'), '-p udp', '-m state', '--state NEW', '-j DROP', verbose=True )
 
 
 

--- a/network.py
+++ b/network.py
@@ -31,14 +31,18 @@ class RestrictedConeNAT(Node):
         print('debug: __init__:', subnet, local_intf, params)
 
         self.subnet = subnet
+
+        if not local_intf:
+            local_intf = self.defaultIntf()
         self.local_intf = local_intf
+
         self.forwardState = self.cmd('sysctl -n net.ipv4.ip_forward').strip()
 
-    def set_manual_config(self, intf):
+    def set_manual_config(self):
         """Prevent network-manager/networkd from messing with our interface
            by specifying manual configuration in /etc/network/interfaces"""
         cfile = '/etc/network/interfaces'
-        line = '\niface %s inet manual\n' % intf
+        line = '\niface %s inet manual\n' % self.local_intf
         try:
             with open(cfile) as f:
                 config = f.read()
@@ -56,10 +60,7 @@ class RestrictedConeNAT(Node):
     def config(self, **params):
         """Configure the NAT and iptables"""
 
-        if not self.local_intf:
-            self.local_intf = self.defaultIntf()
-
-        self.set_manual_config(self.local_intf)
+        self.set_manual_config()
 
         # Now we can configure manually without interference
         super(RestrictedConeNAT, self).config(**params)

--- a/network.py
+++ b/network.py
@@ -27,12 +27,17 @@ from mininet.util import irange
 from mininet.node import Node
 
 class RestrictedConeNAT(Node):
+    # nat1
+    # debug:  192.168.1.0/24 nat1-eth1 False {'ip': '10.0.0.4/8', 'inetIntf': 'nat1-eth0'}
+    # nat2
+    # debug:  192.168.2.0/24 nat2-eth1 False {'ip': '10.0.0.5/8', 'inetIntf': 'nat2-eth0'}
     def __init__( self, name, subnet='10.0/8',
                   localIntf=None, flush=False, **params):
         """Start NAT/forwarding between Mininet and external network
            subnet: Mininet subnet (default 10.0/8)
            flush: flush iptables before installing NAT rules"""
         super( RestrictedConeNAT, self ).__init__( name, **params )
+        print('debug: __init__:', subnet, localIntf, flush, params)
 
         self.subnet = subnet
         self.localIntf = localIntf
@@ -61,6 +66,7 @@ class RestrictedConeNAT(Node):
     def config( self, **params ):
         """Configure the NAT and iptables"""
 
+        print('debug: config:', params)
         if not self.localIntf:
             self.localIntf = self.defaultIntf()
 
@@ -73,21 +79,50 @@ class RestrictedConeNAT(Node):
             self.cmd( 'sysctl net.ipv4.ip_forward=0' )
             self.cmd( 'iptables -F' )
             self.cmd( 'iptables -t nat -F' )
-            # Create default entries for unmatched traffic
-            self.cmd( 'iptables -P INPUT ACCEPT' )
-            self.cmd( 'iptables -P OUTPUT ACCEPT' )
-            self.cmd( 'iptables -P FORWARD DROP' )
+            # self.cmd( 'iptables -P INPUT ACCEPT' )
+            # self.cmd( 'iptables -P OUTPUT ACCEPT' )
+            # self.cmd( 'iptables -P FORWARD DROP' )
+
+        self.cmd( 'iptables -t nat -F' )
+
+        # Create default entries for unmatched traffic
+        self.cmd( 'iptables -P INPUT ACCEPT' )
+        self.cmd( 'iptables -P OUTPUT ACCEPT' )
+        self.cmd( 'iptables -P FORWARD DROP' )
 
         # Install NAT rules
-        self.cmd( 'iptables -I FORWARD',
-                  '-i', self.localIntf, '-d', self.subnet, '-j DROP' )
-        self.cmd( 'iptables -A FORWARD',
-                  '-i', self.localIntf, '-s', self.subnet, '-j ACCEPT' )
-        self.cmd( 'iptables -A FORWARD',
-                  '-o', self.localIntf, '-d', self.subnet, '-j ACCEPT' )
+        # 内部ネットワーク（192.168.0.0/24）から送られてきたパケットの送信元アドレスを、パブリックインターフェイス（eth0）のIPアドレスに変更する（NATを行う）
+        # iptables -t nat -A POSTROUTING -o eth0 -s 192.168.0.0/24 -j MASQUERADE
         self.cmd( 'iptables -t nat -A POSTROUTING',
-                  '-s', self.subnet, "'!'", '-d', self.subnet,
-                  '-j MASQUERADE' )
+                  '-o', params.get('inetIntf'), '-s', self.subnet, '-j MASQUERADE' )
+
+        # パブリックインターフェイス（eth0）から送られてきたパケットを内部ネットワーク（192.168.0.0/24）に転送
+        # iptables -A FORWARD -i eth0 -o eth1 -m state --state RELATED,ESTABLISHED -j ACCEPT
+        self.cmd( 'iptables -A FORWARD',
+                  '-i', params.get('inetIntf'), '-o', self.localIntf, '-m state --state RELATED,ESTABLISHED -j ACCEPT' )
+
+        # 内部ネットワーク（192.168.0.0/24）から送られてきたパケットをパブリックインターフェイス（eth0）に転送
+        # iptables -A FORWARD -i eth1 -o eth0 -j ACCEPT
+        self.cmd( 'iptables -A FORWARD',
+                  '-i', self.localIntf, '-o', params.get('inetIntf'), '-j ACCEPT' )
+
+        # iptables -t nat -A POSTROUTING -o eth1 -p udp -j SNAT --to-source "public IP"
+        # self.cmd( 'iptables -t nat -A POSTROUTING',
+        #           '-o', params.get('inetIntf'), '-p udp', '--to-source', params.get('ip'), '-j SNAT' )
+
+        # iptables -t nat -A PREROUTING -i eth1 -p udp -j DNAT --to-destination "private IP"
+        # self.cmd( 'iptables -t nat -A PREROUTING',
+        #           '-i', params.get('inetIntf'), '-p udp', '--to-destination', params.get('ip'), '-j DNAT' )
+
+        # self.cmd( 'iptables -I FORWARD',
+        #           '-i', self.localIntf, '-d', self.subnet, '-j DROP' )
+        # self.cmd( 'iptables -A FORWARD',
+        #           '-i', self.localIntf, '-s', self.subnet, '-j ACCEPT' )
+        # self.cmd( 'iptables -A FORWARD',
+        #           '-o', self.localIntf, '-d', self.subnet, '-j ACCEPT' )
+        # self.cmd( 'iptables -t nat -A POSTROUTING',
+        #           '-s', self.subnet, "'!'", '-d', self.subnet,
+        #           '-j MASQUERADE' )
 
         # Instruct the kernel to perform forwarding
         self.cmd( 'sysctl net.ipv4.ip_forward=1' )

--- a/network.py
+++ b/network.py
@@ -132,17 +132,18 @@ class NetworkTopology(Topo):
             localIntf = 'nat%d-eth1' % i
             localIP = '192.168.%d.1' % i
             localSubnet = '192.168.%d.0/24' % i
+            hostIp = '192.168.%d.100/24' % i
             natParams = { 'ip' : '%s/24' % localIP }
             # add NAT to topology
             nat = self.addNode('nat%d' % i, cls=RestrictedConeNAT, subnet=localSubnet,
-                               inetIntf=inetIntf, localIntf=localIntf)
+                               inetIntf=inetIntf, localIntf=localIntf, hostIp=hostIp)
             switch = self.addSwitch('s%d' % i)
             # connect NAT to inet and local switches
             self.addLink(nat, inetSwitch, intfName1=inetIntf)
             self.addLink(nat, switch, intfName1=localIntf, params1=natParams)
             # add host and connect to local switch
             host = self.addHost('h%d' % i,
-                                ip='192.168.%d.100/24' % i,
+                                ip=hostIp,
                                 defaultRoute='via %s' % localIP)
             self.addLink(host, switch)
 

--- a/network.py
+++ b/network.py
@@ -27,10 +27,6 @@ from mininet.util import irange
 from mininet.node import Node
 
 class RestrictedConeNAT(Node):
-    # nat1
-    # debug:  192.168.1.0/24 nat1-eth1 False {'ip': '10.0.0.4/8', 'inetIntf': 'nat1-eth0'}
-    # nat2
-    # debug:  192.168.2.0/24 nat2-eth1 False {'ip': '10.0.0.5/8', 'inetIntf': 'nat2-eth0'}
     def __init__( self, name, subnet='10.0/8',
                   localIntf=None, flush=False, **params):
         """Start NAT/forwarding between Mininet and external network
@@ -78,10 +74,6 @@ class RestrictedConeNAT(Node):
         if self.flush:
             self.cmd( 'sysctl net.ipv4.ip_forward=0' )
             self.cmd( 'iptables -F' )
-            self.cmd( 'iptables -t nat -F' )
-            # self.cmd( 'iptables -P INPUT ACCEPT' )
-            # self.cmd( 'iptables -P OUTPUT ACCEPT' )
-            # self.cmd( 'iptables -P FORWARD DROP' )
 
         self.cmd( 'iptables -t nat -F' )
 
@@ -105,24 +97,6 @@ class RestrictedConeNAT(Node):
         # iptables -A FORWARD -i eth1 -o eth0 -j ACCEPT
         self.cmd( 'iptables -A FORWARD',
                   '-i', self.localIntf, '-o', params.get('inetIntf'), '-j ACCEPT' )
-
-        # iptables -t nat -A POSTROUTING -o eth1 -p udp -j SNAT --to-source "public IP"
-        # self.cmd( 'iptables -t nat -A POSTROUTING',
-        #           '-o', params.get('inetIntf'), '-p udp', '--to-source', params.get('ip'), '-j SNAT' )
-
-        # iptables -t nat -A PREROUTING -i eth1 -p udp -j DNAT --to-destination "private IP"
-        # self.cmd( 'iptables -t nat -A PREROUTING',
-        #           '-i', params.get('inetIntf'), '-p udp', '--to-destination', params.get('ip'), '-j DNAT' )
-
-        # self.cmd( 'iptables -I FORWARD',
-        #           '-i', self.localIntf, '-d', self.subnet, '-j DROP' )
-        # self.cmd( 'iptables -A FORWARD',
-        #           '-i', self.localIntf, '-s', self.subnet, '-j ACCEPT' )
-        # self.cmd( 'iptables -A FORWARD',
-        #           '-o', self.localIntf, '-d', self.subnet, '-j ACCEPT' )
-        # self.cmd( 'iptables -t nat -A POSTROUTING',
-        #           '-s', self.subnet, "'!'", '-d', self.subnet,
-        #           '-j MASQUERADE' )
 
         # Instruct the kernel to perform forwarding
         self.cmd( 'sysctl net.ipv4.ip_forward=1' )

--- a/network.py
+++ b/network.py
@@ -89,7 +89,7 @@ class RestrictedConeNAT(Node):
 
         # iptables -t nat -A PREROUTING -i eth1 -p udp -j DNAT --to-destination <private ip goes here>
         self.cmd( 'iptables -t nat -A PREROUTING',
-                  '-i', params.get('inetIntf'), '-p udp', '-j DNAT', '--to-destination', params.get('hostIp'), verbose=True )
+                  '-i', params.get('inetIntf'), '-p udp', '-j DNAT', '--to-destination', params.get('hostIp').split('/')[0], verbose=True )
 
         # iptables -A INPUT -i eth1 -p udp -m state --state ESTABLISHED,RELATED -j ACCEPT
         self.cmd( 'iptables -A INPUT',

--- a/network.py
+++ b/network.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 """
-natnet.py: Example network with NATs
+Network with Restricted Cone NATs
 
            h0
            |
@@ -14,7 +14,6 @@ natnet.py: Example network with NATs
    s1              s2
     |              |
    h1              h2
-
 """
 
 from mininet.topo import Topo
@@ -25,118 +24,160 @@ from mininet.cli import CLI
 from mininet.util import irange
 from mininet.node import Node
 
+
 class RestrictedConeNAT(Node):
-    def __init__( self, name, subnet='10.0/8',
-                  localIntf=None, flush=False, **params):
-        """Start NAT/forwarding between Mininet and external network
-           subnet: Mininet subnet (default 10.0/8)
-           flush: flush iptables before installing NAT rules"""
-        super( RestrictedConeNAT, self ).__init__( name, **params )
-        print('debug: __init__:', subnet, localIntf, flush, params)
+    def __init__(self, name, subnet='10.0/8', localIntf=None, **params):
+        super(RestrictedConeNAT, self).__init__(name, **params)
+        print('debug: __init__:', subnet, localIntf, params)
 
         self.subnet = subnet
         self.localIntf = localIntf
-        self.flush = flush
-        self.forwardState = self.cmd( 'sysctl -n net.ipv4.ip_forward' ).strip()
+        self.forwardState = self.cmd('sysctl -n net.ipv4.ip_forward').strip()
 
-    def setManualConfig( self, intf ):
+    def setManualConfig(self, intf):
         """Prevent network-manager/networkd from messing with our interface
            by specifying manual configuration in /etc/network/interfaces"""
         cfile = '/etc/network/interfaces'
         line = '\niface %s inet manual\n' % intf
         try:
-            with open( cfile ) as f:
+            with open(cfile) as f:
                 config = f.read()
         except IOError:
             config = ''
-        if ( line ) not in config:
-            info( '*** Adding "' + line.strip() + '" to ' + cfile + '\n' )
-            with open( cfile, 'a' ) as f:
-                f.write( line )
+        if line not in config:
+            info('*** Adding "' + line.strip() + '" to ' + cfile + '\n')
+            with open(cfile, 'a') as f:
+                f.write(line)
             # Probably need to restart network manager to be safe -
             # hopefully this won't disconnect you
-            self.cmd( 'service network-manager restart || netplan apply' )
+            self.cmd('service network-manager restart || netplan apply')
 
     # pylint: disable=arguments-differ
-    def config( self, **params ):
+    def config(self, **params):
         """Configure the NAT and iptables"""
 
-        print('debug: config:', params)
         if not self.localIntf:
             self.localIntf = self.defaultIntf()
 
-        self.setManualConfig( self.localIntf )
+        self.setManualConfig(self.localIntf)
 
         # Now we can configure manually without interference
         super(RestrictedConeNAT, self).config(**params)
 
-        self.cmd( 'iptables -F' )
-        self.cmd( 'iptables -t nat -F' )
+        self.cmd('iptables -F')
+        self.cmd('iptables -t nat -F')
 
         # Create default entries for unmatched traffic
-        self.cmd( 'iptables -P INPUT ACCEPT' )
-        self.cmd( 'iptables -P OUTPUT ACCEPT' )
-        self.cmd( 'iptables -P FORWARD ACCEPT' )
+        self.cmd('iptables -P INPUT ACCEPT')
+        self.cmd('iptables -P OUTPUT ACCEPT')
+        self.cmd('iptables -P FORWARD ACCEPT')
 
         # Install NAT rules
         # iptables -t nat -A POSTROUTING -o nat1-eth0 -p udp -j SNAT --to-source <public ip>
-        self.cmd( 'iptables -t nat -A POSTROUTING',
-                  '-o', params.get('inetIntf'), '-p udp', '-j SNAT', '--to-source', params.get('ip').split('/')[0], verbose=True )
+        self.cmd(
+            'iptables -t nat -A POSTROUTING',
+            '-o',
+            params.get('inetIntf'),
+            '-p udp',
+            '-j SNAT',
+            '--to-source',
+            params.get('ip').split('/')[0],
+            verbose=True
+        )
 
         # iptables -t nat -A PREROUTING -i eth1 -p udp -j DNAT --to-destination <private ip>
-        self.cmd( 'iptables -t nat -A PREROUTING',
-                  '-i', params.get('inetIntf'), '-p udp', '-j DNAT', '--to-destination', params.get('hostIp').split('/')[0], verbose=True )
+        self.cmd(
+            'iptables -t nat -A PREROUTING',
+            '-i',
+            params.get('inetIntf'),
+            '-p udp',
+            '-j DNAT',
+            '--to-destination',
+            params.get('hostIp').split('/')[0],
+            verbose=True
+        )
 
         # iptables -A FORWARD -i eth1 -p udp -m state --state ESTABLISHED,RELATED -j ACCEPT
-        self.cmd( 'iptables -A FORWARD',
-                  '-i', params.get('inetIntf'), '-p udp', '-m state', '--state ESTABLISHED,RELATED', '-j ACCEPT', verbose=True )
+        self.cmd(
+            'iptables -A FORWARD',
+            '-i',
+            params.get('inetIntf'),
+            '-p udp',
+            '-m state',
+            '--state ESTABLISHED,RELATED',
+            '-j ACCEPT',
+            verbose=True
+        )
 
         # iptables -A FORWARD -i eth1 -p udp -m state --state NEW -j DROP
-        self.cmd( 'iptables -A FORWARD',
-                  '-i', params.get('inetIntf'), '-p udp', '-m state', '--state NEW', '-j DROP', verbose=True )
+        self.cmd(
+            'iptables -A FORWARD',
+            '-i',
+            params.get('inetIntf'),
+            '-p udp',
+            '-m state',
+            '--state NEW',
+            '-j DROP',
+            verbose=True
+        )
 
         # Instruct the kernel to perform forwarding
-        self.cmd( 'sysctl net.ipv4.ip_forward=1' )
+        self.cmd('sysctl net.ipv4.ip_forward=1' )
 
-    def terminate( self ):
-        self.cmd( 'iptables -F' )
-        self.cmd( 'iptables -t nat -F' )
+    def terminate(self ):
+        self.cmd('iptables -F')
+        self.cmd('iptables -t nat -F')
         # Put the forwarding state back to what it was
-        self.cmd( 'sysctl net.ipv4.ip_forward=%s' % self.forwardState )
+        self.cmd('sysctl net.ipv4.ip_forward=%s' % self.forwardState)
         super(RestrictedConeNAT, self).terminate()
+
 
 class NetworkTopology(Topo):
     # pylint: disable=arguments-differ
-    def build(self, n=2, **_kwargs ):
+    def build(self, n=2, **_kwargs):
         # set up inet switch
-        inetSwitch = self.addSwitch('s0')
-        # add inet host
-        inetHost = self.addHost('h0')
-        self.addLink(inetSwitch, inetHost)
+        inet_switch = self.addSwitch('s0')
+        # add bootstrap node
+        inet_host = self.addHost('h0')
+        self.addLink(inet_switch, inet_host)
 
         # add local nets
         for i in irange(1, n):
-            inetIntf = 'nat%d-eth0' % i
-            localIntf = 'nat%d-eth1' % i
-            localIP = '192.168.%d.1' % i
-            localSubnet = '192.168.%d.0/24' % i
-            hostIp = '192.168.%d.100/24' % i
-            natParams = { 'ip' : '%s/24' % localIP }
+            inet_intf = 'nat%d-eth0' % i
+            local_intf = 'nat%d-eth1' % i
+            local_ip = '192.168.%d.1' % i
+            local_subnet = '192.168.%d.0/24' % i
+            host_ip = '192.168.%d.100/24' % i
+            nat_params = {'ip': '%s/24' % local_ip}
+
             # add NAT to topology
-            nat = self.addNode('nat%d' % i, cls=RestrictedConeNAT, subnet=localSubnet,
-                               inetIntf=inetIntf, localIntf=localIntf, hostIp=hostIp)
+            nat = self.addNode(
+                'nat%d' % i,
+                cls=RestrictedConeNAT,
+                subnet=local_subnet,
+                inetIntf=inet_intf,
+                localIntf=local_intf,
+                hostIp=host_ip
+            )
+
+            # add local switch to topology
             switch = self.addSwitch('s%d' % i)
+
             # connect NAT to inet and local switches
-            self.addLink(nat, inetSwitch, intfName1=inetIntf)
-            self.addLink(nat, switch, intfName1=localIntf, params1=natParams)
+            self.addLink(nat, inet_switch, intfName1=inet_intf)
+            self.addLink(nat, switch, intfName1=local_intf, params1=nat_params)
+
             # add host and connect to local switch
-            host = self.addHost('h%d' % i,
-                                ip=hostIp,
-                                defaultRoute='via %s' % localIP)
+            host = self.addHost(
+                'h%d' % i,
+                ip=host_ip,
+                defaultRoute='via %s' % local_ip
+            )
             self.addLink(host, switch)
 
+
 def run():
-    "Create network and run the CLI"
+    """Create network and run the CLI"""
     topo = NetworkTopology()
     net = Mininet(topo=topo, waitConnected=True)
     net.start()

--- a/network.py
+++ b/network.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+
+"""
+natnet.py: Example network with NATs
+
+
+           h0
+           |
+           s0
+           |
+    ----------------
+    |              |
+   nat1           nat2
+    |              |
+   s1              s2
+    |              |
+   h1              h2
+
+"""
+
+from mininet.topo import Topo
+from mininet.net import Mininet
+from mininet.nodelib import NAT
+from mininet.log import setLogLevel
+from mininet.log import info
+from mininet.cli import CLI
+from mininet.util import irange
+# from mininet.node import Node
+
+class RestrictedConeNAT(NAT):
+
+    # def __init__( self, name, subnet='10.0/8',
+    #               localIntf=None, flush=False, **params):
+    #     """Start NAT/forwarding between Mininet and external network
+    #        subnet: Mininet subnet (default 10.0/8)
+    #        flush: flush iptables before installing NAT rules"""
+    #     super(RestrictedConeNAT, self).__init__(name, **params)
+    #
+    #     self.subnet = subnet
+    #     self.localIntf = localIntf
+    #     self.flush = flush
+    #     self.forwardState = self.cmd( 'sysctl -n net.ipv4.ip_forward' ).strip()
+    #
+    # def setManualConfig( self, intf ):
+    #     """Prevent network-manager/networkd from messing with our interface
+    #        by specifying manual configuration in /etc/network/interfaces"""
+    #     cfile = '/etc/network/interfaces'
+    #     line = '\niface %s inet manual\n' % intf
+    #     try:
+    #         with open( cfile ) as f:
+    #             config = f.read()
+    #     except IOError:
+    #         config = ''
+    #     if ( line ) not in config:
+    #         info( '*** Adding "' + line.strip() + '" to ' + cfile + '\n' )
+    #         with open( cfile, 'a' ) as f:
+    #             f.write( line )
+    #         # Probably need to restart network manager to be safe -
+    #         # hopefully this won't disconnect you
+    #         self.cmd( 'service network-manager restart || netplan apply' )
+    #
+    # # pylint: disable=arguments-differ
+    # def config( self, **params ):
+    #     """Configure the NAT and iptables"""
+    #
+    #     if not self.localIntf:
+    #         self.localIntf = self.defaultIntf()
+    #
+    #     self.setManualConfig( self.localIntf )
+    #
+    #     # Now we can configure manually without interference
+    #     super(RestrictedConeNAT, self).config(**params)
+    #
+    #     if self.flush:
+    #         self.cmd( 'sysctl net.ipv4.ip_forward=0' )
+    #         self.cmd( 'iptables -F' )
+    #         self.cmd( 'iptables -t nat -F' )
+    #         # Create default entries for unmatched traffic
+    #         self.cmd( 'iptables -P INPUT ACCEPT' )
+    #         self.cmd( 'iptables -P OUTPUT ACCEPT' )
+    #         self.cmd( 'iptables -P FORWARD DROP' )
+    #
+    #     # Install NAT rules
+    #     self.cmd( 'iptables -I FORWARD',
+    #               '-i', self.localIntf, '-d', self.subnet, '-j DROP' )
+    #     self.cmd( 'iptables -A FORWARD',
+    #               '-i', self.localIntf, '-s', self.subnet, '-j ACCEPT' )
+    #     self.cmd( 'iptables -A FORWARD',
+    #               '-o', self.localIntf, '-d', self.subnet, '-j ACCEPT' )
+    #     self.cmd( 'iptables -t nat -A POSTROUTING',
+    #               '-s', self.subnet, "'!'", '-d', self.subnet,
+    #               '-j MASQUERADE' )
+    #
+    #     # Instruct the kernel to perform forwarding
+    #     self.cmd( 'sysctl net.ipv4.ip_forward=1' )
+    #
+    # def terminate( self ):
+    #     "Stop NAT/forwarding between Mininet and external network"
+    #     # Remote NAT rules
+    #     self.cmd( 'iptables -D FORWARD',
+    #               '-i', self.localIntf, '-d', self.subnet, '-j DROP' )
+    #     self.cmd( 'iptables -D FORWARD',
+    #               '-i', self.localIntf, '-s', self.subnet, '-j ACCEPT' )
+    #     self.cmd( 'iptables -D FORWARD',
+    #               '-o', self.localIntf, '-d', self.subnet, '-j ACCEPT' )
+    #     self.cmd( 'iptables -t nat -D POSTROUTING',
+    #               '-s', self.subnet, '\'!\'', '-d', self.subnet,
+    #               '-j MASQUERADE' )
+    #     # Put the forwarding state back to what it was
+    #     self.cmd( 'sysctl net.ipv4.ip_forward=%s' % self.forwardState )
+    #     super(RestrictedConeNAT, self).terminate()
+
+class NetworkTopology(Topo):
+    # pylint: disable=arguments-differ
+    def build(self, n=2, **_kwargs ):
+        # set up inet switch
+        inetSwitch = self.addSwitch('s0')
+        # add inet host
+        inetHost = self.addHost('h0')
+        self.addLink(inetSwitch, inetHost)
+
+        # add local nets
+        for i in irange(1, n):
+            inetIntf = 'nat%d-eth0' % i
+            localIntf = 'nat%d-eth1' % i
+            localIP = '192.168.%d.1' % i
+            localSubnet = '192.168.%d.0/24' % i
+            natParams = { 'ip' : '%s/24' % localIP }
+            # add NAT to topology
+            nat = self.addNode('nat%d' % i, cls=RestrictedConeNAT, subnet=localSubnet,
+                               inetIntf=inetIntf, localIntf=localIntf)
+            switch = self.addSwitch('s%d' % i)
+            # connect NAT to inet and local switches
+            self.addLink(nat, inetSwitch, intfName1=inetIntf)
+            self.addLink(nat, switch, intfName1=localIntf, params1=natParams)
+            # add host and connect to local switch
+            host = self.addHost('h%d' % i,
+                                ip='192.168.%d.100/24' % i,
+                                defaultRoute='via %s' % localIP)
+            self.addLink(host, switch)
+
+def run():
+    "Create network and run the CLI"
+    topo = NetworkTopology()
+    net = Mininet(topo=topo, waitConnected=True)
+    net.start()
+    CLI(net)
+    net.stop()
+
+
+if __name__ == '__main__':
+    setLogLevel('info')
+    run()

--- a/sequence.drawio
+++ b/sequence.drawio
@@ -1,0 +1,181 @@
+<mxfile host="65bd71144e">
+    <diagram id="ExdccTZqctQwAvQB16s_" name="Page-1">
+        <mxGraphModel dx="1976" dy="1072" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="0" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="50" value="" style="endArrow=none;dashed=1;html=1;fontSize=12;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="1" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="60" y="888" as="sourcePoint"/>
+                        <mxPoint x="60" y="161" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="51" value="" style="endArrow=none;dashed=1;html=1;fontSize=12;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="1" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="419" y="928" as="sourcePoint"/>
+                        <mxPoint x="420" y="160" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="52" value="" style="endArrow=classic;html=1;" parent="1" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="59" y="236" as="sourcePoint"/>
+                        <mxPoint x="419" y="236" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="108" value="Send message to host0." style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="52">
+                    <mxGeometry x="-0.3278" y="-3" relative="1" as="geometry">
+                        <mxPoint x="-57" y="-16" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="54" value="" style="endArrow=classic;html=1;" parent="1" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="418" y="417" as="sourcePoint"/>
+                        <mxPoint x="63" y="417" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="109" value="Notify host2's external ip/port." style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="54">
+                    <mxGeometry x="0.3577" y="1" relative="1" as="geometry">
+                        <mxPoint x="158" y="-16" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="56" value="" style="endArrow=classic;html=1;" parent="1" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="751" y="288" as="sourcePoint"/>
+                        <mxPoint x="416.5" y="285" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="111" value="Send messge to host0." style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="56">
+                    <mxGeometry x="-0.5395" y="-1" relative="1" as="geometry">
+                        <mxPoint x="20" y="-10" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="59" value="" style="endArrow=none;dashed=1;html=1;fontSize=12;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="1" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="753" y="931" as="sourcePoint"/>
+                        <mxPoint x="754" y="159" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="61" value="" style="endArrow=none;dashed=1;html=1;fontSize=12;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="1" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="242" y="904" as="sourcePoint"/>
+                        <mxPoint x="239.5" y="161" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="63" value="" style="endArrow=none;dashed=1;html=1;fontSize=12;entryX=0.5;entryY=1;entryDx=0;entryDy=0;startArrow=none;" parent="1" edge="1" source="105">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="597" y="940" as="sourcePoint"/>
+                        <mxPoint x="596.5" y="164" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="73" value="" style="endArrow=classic;html=1;startArrow=none;" parent="1" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="63" y="727" as="sourcePoint"/>
+                        <mxPoint x="748" y="727" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="83" value="&lt;span style=&quot;font-family: -apple-system, &amp;quot;system-ui&amp;quot;, &amp;quot;Segoe UI&amp;quot;, &amp;quot;Noto Sans&amp;quot;, Helvetica, Arial, sans-serif, &amp;quot;Apple Color Emoji&amp;quot;, &amp;quot;Segoe UI Emoji&amp;quot;; font-size: 14px; text-align: left; background-color: rgb(13, 17, 23);&quot;&gt;This triggers nat1&lt;br&gt;to allow and route incoming packets&lt;br&gt;&amp;nbsp;from the host2's external ip/port.&lt;/span&gt;" style="shape=note;whiteSpace=wrap;html=1;backgroundOutline=1;darkOpacity=0.05;fontColor=#00CC00;" parent="1" vertex="1">
+                    <mxGeometry x="-279" y="537" width="271" height="92" as="geometry"/>
+                </mxCell>
+                <mxCell id="85" value="" style="endArrow=none;dashed=1;html=1;fontSize=12;entryX=0;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0;exitDx=271;exitDy=61;exitPerimeter=0;" parent="1" source="83" target="104" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="684.5" y="747.5" as="sourcePoint"/>
+                        <mxPoint x="213.5" y="564" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="86" value="" style="endArrow=classic;html=1;" edge="1" parent="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="425" y="464" as="sourcePoint"/>
+                        <mxPoint x="755" y="464" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="110" value="Notify host1's external ip/port." style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="86">
+                    <mxGeometry x="-0.7939" y="-1" relative="1" as="geometry">
+                        <mxPoint x="44" y="-20" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="90" value="" style="endArrow=classic;html=1;startArrow=none;" edge="1" parent="1" source="101">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="753" y="633" as="sourcePoint"/>
+                        <mxPoint x="64" y="633" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="92" value="&lt;span style=&quot;font-family: -apple-system, &amp;quot;system-ui&amp;quot;, &amp;quot;Segoe UI&amp;quot;, &amp;quot;Noto Sans&amp;quot;, Helvetica, Arial, sans-serif, &amp;quot;Apple Color Emoji&amp;quot;, &amp;quot;Segoe UI Emoji&amp;quot;; font-size: 14px; text-align: left; background-color: rgb(13, 17, 23);&quot;&gt;This triggers nat2&lt;br&gt;to allow and route incoming packets&lt;br&gt;&amp;nbsp;from the host1's external ip/port.&lt;/span&gt;" style="shape=note;whiteSpace=wrap;html=1;backgroundOutline=1;darkOpacity=0.05;fontColor=#00CC00;" vertex="1" parent="1">
+                    <mxGeometry x="857" y="517" width="271" height="92" as="geometry"/>
+                </mxCell>
+                <mxCell id="93" value="" style="endArrow=none;dashed=1;html=1;fontSize=12;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0;exitDx=0;exitDy=0;entryPerimeter=0;" edge="1" parent="1" source="105" target="92">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="622.5" y="623.75" as="sourcePoint"/>
+                        <mxPoint x="223.5" y="574" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="94" value="" style="rounded=1;whiteSpace=wrap;html=1;strokeWidth=2;fillWeight=4;hachureGap=8;hachureAngle=45;fillColor=#FF0000;sketch=1;fontColor=#00CC00;" vertex="1" parent="1">
+                    <mxGeometry x="570.5" y="530" width="52" height="39" as="geometry"/>
+                </mxCell>
+                <mxCell id="100" value="" style="endArrow=none;dashed=1;html=1;fontSize=12;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" edge="1" parent="1" target="99">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="597" y="940" as="sourcePoint"/>
+                        <mxPoint x="596.5" y="164" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="99" value="" style="rounded=1;whiteSpace=wrap;html=1;strokeWidth=2;fillWeight=4;hachureGap=8;hachureAngle=45;fillColor=#00FF00;sketch=1;fontColor=#00CC00;" vertex="1" parent="1">
+                    <mxGeometry x="570.5" y="712" width="52" height="39" as="geometry"/>
+                </mxCell>
+                <mxCell id="102" value="" style="endArrow=none;html=1;startArrow=none;" edge="1" parent="1" target="101">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="752" y="634" as="sourcePoint"/>
+                        <mxPoint x="64" y="633" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="120" value="Send message to host1's external address." style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="102">
+                    <mxGeometry x="-0.7575" y="-1" relative="1" as="geometry">
+                        <mxPoint x="70" y="-17" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="101" value="" style="rounded=1;whiteSpace=wrap;html=1;strokeWidth=2;fillWeight=4;hachureGap=8;hachureAngle=45;fillColor=#00FF00;sketch=1;fontColor=#00CC00;" vertex="1" parent="1">
+                    <mxGeometry x="213.5" y="616" width="52" height="39" as="geometry"/>
+                </mxCell>
+                <mxCell id="103" value="" style="endArrow=classic;html=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" target="94">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="63" y="548" as="sourcePoint"/>
+                        <mxPoint x="423" y="548" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="119" value="Send message to host2's external address." style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];" vertex="1" connectable="0" parent="103">
+                    <mxGeometry x="-0.7833" relative="1" as="geometry">
+                        <mxPoint x="-39" y="-15" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="104" value="" style="shape=ellipse;html=1;dashed=0;whitespace=wrap;perimeter=ellipsePerimeter;fillColor=#3399FF;" vertex="1" parent="1">
+                    <mxGeometry x="231" y="537" width="22" height="22" as="geometry"/>
+                </mxCell>
+                <mxCell id="106" value="" style="endArrow=none;dashed=1;html=1;fontSize=12;entryX=0.5;entryY=1;entryDx=0;entryDy=0;startArrow=none;" edge="1" parent="1" source="99" target="105">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="596.5" y="712" as="sourcePoint"/>
+                        <mxPoint x="596.5" y="241" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="105" value="" style="shape=ellipse;html=1;dashed=0;whitespace=wrap;perimeter=ellipsePerimeter;fillColor=#3399FF;" vertex="1" parent="1">
+                    <mxGeometry x="585.5" y="624.5" width="22" height="22" as="geometry"/>
+                </mxCell>
+                <mxCell id="113" value="Host0 recognizes the external ip/port&lt;br&gt;&amp;nbsp;of host1 and host2." style="html=1;dashed=0;whitespace=wrap;fillColor=default;" vertex="1" parent="1">
+                    <mxGeometry x="307" y="311" width="226" height="63" as="geometry"/>
+                </mxCell>
+                <mxCell id="114" value="host1" style="shape=mxgraph.cisco.computers_and_peripherals.pc;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" vertex="1" parent="1">
+                    <mxGeometry x="38" y="91.82" width="47" height="42.18" as="geometry"/>
+                </mxCell>
+                <mxCell id="115" value="host0" style="shape=mxgraph.cisco.computers_and_peripherals.pc;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" vertex="1" parent="1">
+                    <mxGeometry x="396.5" y="94" width="47" height="42.18" as="geometry"/>
+                </mxCell>
+                <mxCell id="116" value="host2" style="shape=mxgraph.cisco.computers_and_peripherals.pc;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" vertex="1" parent="1">
+                    <mxGeometry x="732" y="94" width="47" height="42.18" as="geometry"/>
+                </mxCell>
+                <mxCell id="117" value="nat1" style="shape=mxgraph.cisco.routers.router;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" vertex="1" parent="1">
+                    <mxGeometry x="218" y="98.3" width="43" height="29.22" as="geometry"/>
+                </mxCell>
+                <mxCell id="118" value="nat2" style="shape=mxgraph.cisco.routers.router;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" vertex="1" parent="1">
+                    <mxGeometry x="575" y="104.78" width="43" height="29.22" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/server.py
+++ b/server.py
@@ -1,4 +1,3 @@
-import logging
 import socket
 import sys
 from util import *

--- a/server.py
+++ b/server.py
@@ -1,0 +1,33 @@
+import logging
+import socket
+import sys
+from util import *
+
+logger = logging.getLogger()
+addresses = []
+
+
+def main(host='0.0.0.0', port=9999):
+    sock = socket.socket(socket.AF_INET, # Internet
+                         socket.SOCK_DGRAM) # UDP
+    sock.bind((host, port))
+    logger.info("server: listening on %s:%s", host, port)
+
+    while True:
+        logger.info("server: waiting for messages...")
+        data, addr = sock.recvfrom(1024) # buffer size is 1024 bytes
+        logger.info("server: received a message from %s", addr)
+        addresses.append(addr)
+
+        if len(addresses) >= 2:
+            logger.info("server: send client info to: %s", addresses[0])
+            sock.sendto(addr_to_msg(addresses[1]), addresses[0])
+            logger.info("server: send client info to: %s", addresses[1])
+            sock.sendto(addr_to_msg(addresses[0]), addresses[1])
+            addresses.pop(1)
+            addresses.pop(0)
+
+
+if __name__ == '__main__':
+    init_logger()
+    main(*addr_from_args(sys.argv))

--- a/topology.drawio
+++ b/topology.drawio
@@ -1,0 +1,121 @@
+<mxfile host="65bd71144e">
+    <diagram id="ExdccTZqctQwAvQB16s_" name="Page-1">
+        <mxGraphModel dx="1976" dy="1072" grid="0" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="0" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="87" value="" style="shape=mxgraph.cisco.routers.router;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" parent="1" vertex="1">
+                    <mxGeometry x="-187" y="469" width="78" height="53" as="geometry"/>
+                </mxCell>
+                <mxCell id="88" value="" style="shape=mxgraph.cisco.computers_and_peripherals.pc;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" parent="1" vertex="1">
+                    <mxGeometry x="8" y="134" width="78" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="89" value="" style="shape=mxgraph.cisco.routers.router;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" parent="1" vertex="1">
+                    <mxGeometry x="215" y="459" width="78" height="53" as="geometry"/>
+                </mxCell>
+                <mxCell id="91" value="" style="shape=mxgraph.cisco.hubs_and_gateways.small_hub;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" parent="1" vertex="1">
+                    <mxGeometry x="3" y="357" width="90" height="45" as="geometry"/>
+                </mxCell>
+                <mxCell id="92" value="" style="shape=mxgraph.cisco.hubs_and_gateways.small_hub;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" parent="1" vertex="1">
+                    <mxGeometry x="-193" y="613" width="90" height="45" as="geometry"/>
+                </mxCell>
+                <mxCell id="93" value="" style="shape=mxgraph.cisco.hubs_and_gateways.small_hub;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" parent="1" vertex="1">
+                    <mxGeometry x="208" y="624" width="90" height="45" as="geometry"/>
+                </mxCell>
+                <mxCell id="94" value="" style="shape=mxgraph.cisco.computers_and_peripherals.pc;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" parent="1" vertex="1">
+                    <mxGeometry x="-187" y="778" width="78" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="95" value="" style="shape=mxgraph.cisco.computers_and_peripherals.pc;sketch=0;html=1;pointerEvents=1;dashed=0;fillColor=#036897;strokeColor=#ffffff;strokeWidth=2;verticalLabelPosition=bottom;verticalAlign=top;align=center;outlineConnect=0;" parent="1" vertex="1">
+                    <mxGeometry x="215" y="780" width="78" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="97" value="" style="endArrow=none;html=1;fontSize=12;entryX=0.5;entryY=0;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" parent="1" source="106" target="91" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="47" y="268" as="sourcePoint"/>
+                        <mxPoint x="275" y="1005" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="98" value="" style="endArrow=none;html=1;fontSize=12;exitX=0;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="91" target="87" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="57" y="214" as="sourcePoint"/>
+                        <mxPoint x="54" y="365" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="99" value="" style="endArrow=none;html=1;fontSize=12;entryX=0.5;entryY=0;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="91" target="89" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="9" y="410" as="sourcePoint"/>
+                        <mxPoint x="-138" y="479" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="100" value="" style="endArrow=none;html=1;fontSize=12;entryX=0.5;entryY=0;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="87" target="92" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="9" y="410" as="sourcePoint"/>
+                        <mxPoint x="-138" y="479" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="101" value="" style="endArrow=none;html=1;fontSize=12;entryX=0.5;entryY=0;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="89" target="93" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="99" y="407.1071428571429" as="sourcePoint"/>
+                        <mxPoint x="264" y="479" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="103" value="" style="endArrow=none;html=1;fontSize=12;exitX=0.5;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="92" target="94" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="-139.35319148936173" y="532" as="sourcePoint"/>
+                        <mxPoint x="-144" y="623" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="104" value="" style="endArrow=none;html=1;fontSize=12;entryX=0.5;entryY=0;entryDx=0;entryDy=0;entryPerimeter=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="93" target="95" edge="1">
+                    <mxGeometry width="50" height="50" relative="1" as="geometry">
+                        <mxPoint x="258" y="668" as="sourcePoint"/>
+                        <mxPoint x="266" y="629" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="106" value="10.0.0.1/8" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="17" y="210" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="107" value="host0" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="21" y="93" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="108" value="nat1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="-247" y="477" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="109" value="switch0" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="18" y="417" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="110" value="nat2" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="298" y="470.5" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="111" value="host1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="-180" y="854" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="112" value="host2" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="226" y="856" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="113" value="switch1" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="-253" y="624" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="114" value="switch2" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="305" y="628" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="115" value="192.168.1.100/24" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="-230" y="744" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="116" value="192.168.1.1/24" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="-223" y="525" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="117" value="10.0.0.4/8" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="-185" y="432" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="118" value="10.0.0.5/8" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="250" y="417" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="119" value="192.168.2.1/24" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="278" y="512" width="60" height="30" as="geometry"/>
+                </mxCell>
+                <mxCell id="120" value="192.168.2.100/24" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontStyle=1" parent="1" vertex="1">
+                    <mxGeometry x="278" y="744" width="60" height="30" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/util.py
+++ b/util.py
@@ -1,8 +1,9 @@
-import struct
 import logging
+
 
 def init_logger():
     logging.basicConfig(level=logging.INFO, filename='/tmp/udp-hole-punching.log', format='%(asctime)s - %(message)s')
+
 
 def addr_from_args(args, host='127.0.0.1', port=9999):
     if len(args) >= 3:
@@ -16,7 +17,7 @@ def addr_from_args(args, host='127.0.0.1', port=9999):
 
 def msg_to_addr(data):
     ip, port = data.decode('utf-8').strip().split(':')
-    return (ip, int(port))
+    return ip, int(port)
 
 
 def addr_to_msg(addr):

--- a/util.py
+++ b/util.py
@@ -1,0 +1,23 @@
+import struct
+import logging
+
+def init_logger():
+    logging.basicConfig(level=logging.INFO, filename='/tmp/udp-hole-punching.log', format='%(asctime)s - %(message)s')
+
+def addr_from_args(args, host='127.0.0.1', port=9999):
+    if len(args) >= 3:
+        host, port = args[1], int(args[2])
+    elif len(args) == 2:
+        host, port = host, int(args[1])
+    else:
+        host, port = host, port
+    return host, port
+
+
+def msg_to_addr(data):
+    ip, port = data.decode('utf-8').strip().split(':')
+    return (ip, int(port))
+
+
+def addr_to_msg(addr):
+    return '{}:{}'.format(addr[0], str(addr[1])).encode('utf-8')


### PR DESCRIPTION
This repository provides a simulated _Restricted Cone NAT_ environment using [Mininet](https://mininet.org/) and iptables, and Python scripts for UDP hole punching.

Note that only Linux is supported since Mininet depends on the Linux network namespaces.

## Network Topology

<img width="750" alt="image" src="https://github.com/ackintosh/udp-hole-punching/assets/1885716/3acf9460-b4ec-4eca-be6d-21f6d858e550">

## UDP Hole Punching

```bash
# Start up the topology and run the Mininet CLI.
$ sudo python3 udp-hole-punching/network.py

# Run server script (bootstrap node) in the background.
mininet> h0 python3 -u udp-hole-punching/server.py 0.0.0.0 9000 &

# Run client script at h1.
mininet> h1 python3 -u udp-hole-punching/client.py h0 9000 &

# Run client script at h2. 
mininet> h2 python3 -u udp-hole-punching/client.py h0 9000 &

# See the logs by the server and clients.
mininet> h1 cat /tmp/udp-hole-punching.log

# See the iptable status of nat* nodes.
mininet> nat1 iptables -L -v -n
mininet> nat2 iptables -L -v -n
```

<img width="1468" alt="image" src="https://github.com/ackintosh/udp-hole-punching/assets/1885716/307d9944-5885-44c9-a51e-84e72449b46c">
